### PR TITLE
Fix Haswell `gemmsup` kernel out-of-bounds crash

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -23,6 +23,7 @@ but many others have contributed code and feedback, including
   Dilyn Corner             @dilyn-corner
   Mat Cross                @matcross           (NAG)
                            @decandia50
+  Daniël de Kok            @danieldk           (Explosion)
   Kay Dewhurst             @jkd2016            (Max Planck Institute, Halle, Germany)
   Jeff Diamond                                 (Oracle)
   Johannes Dieterich       @iotamudelta

--- a/kernels/haswell/3/sup/s6x16/bli_gemmsup_rv_haswell_asm_sMx2.c
+++ b/kernels/haswell/3/sup/s6x16/bli_gemmsup_rv_haswell_asm_sMx2.c
@@ -93,8 +93,8 @@ void bli_sgemmsup_rv_haswell_asm_6x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t*          data,
-       cntx_t*             cntx
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );
@@ -570,8 +570,8 @@ void bli_sgemmsup_rv_haswell_asm_5x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t*          data,
-       cntx_t*             cntx
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );
@@ -1032,8 +1032,8 @@ void bli_sgemmsup_rv_haswell_asm_4x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t*          data,
-       cntx_t*             cntx
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );
@@ -1443,8 +1443,8 @@ void bli_sgemmsup_rv_haswell_asm_3x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t*          data,
-       cntx_t*             cntx
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );
@@ -1846,8 +1846,8 @@ void bli_sgemmsup_rv_haswell_asm_2x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t*          data,
-       cntx_t*             cntx
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );
@@ -2198,8 +2198,8 @@ void bli_sgemmsup_rv_haswell_asm_1x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t*          data,
-       cntx_t*             cntx
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );

--- a/kernels/haswell/3/sup/s6x16/bli_gemmsup_rv_haswell_asm_sMx2.c
+++ b/kernels/haswell/3/sup/s6x16/bli_gemmsup_rv_haswell_asm_sMx2.c
@@ -389,32 +389,38 @@ void bli_sgemmsup_rv_haswell_asm_6x2
 	label(.SROWSTORED)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm4)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm4)
 	vmovsd(xmm4, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm6)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm6)
 	vmovsd(xmm6, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm8)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm8)
 	vmovsd(xmm8, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm10)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm10)
 	vmovsd(xmm10, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm12)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm12)
 	vmovsd(xmm12, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm14)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm14)
 	vmovsd(xmm14, mem(rcx, 0*32))
 	//add(rdi, rcx)
 	
@@ -848,27 +854,32 @@ void bli_sgemmsup_rv_haswell_asm_5x2
 	label(.SROWSTORED)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm4)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm4)
 	vmovsd(xmm4, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm6)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm6)
 	vmovsd(xmm6, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm8)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm8)
 	vmovsd(xmm8, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm10)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm10)
 	vmovsd(xmm10, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm12)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm12)
 	vmovsd(xmm12, mem(rcx, 0*32))
 	//add(rdi, rcx)
 	
@@ -1288,22 +1299,26 @@ void bli_sgemmsup_rv_haswell_asm_4x2
 	label(.SROWSTORED)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm4)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm4)
 	vmovsd(xmm4, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm6)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm6)
 	vmovsd(xmm6, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm8)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm8)
 	vmovsd(xmm8, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm10)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm10)
 	vmovsd(xmm10, mem(rcx, 0*32))
 	//add(rdi, rcx)
 	
@@ -1683,17 +1698,20 @@ void bli_sgemmsup_rv_haswell_asm_3x2
 	label(.SROWSTORED)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm4)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm4)
 	vmovsd(xmm4, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm6)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm6)
 	vmovsd(xmm6, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm8)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm8)
 	vmovsd(xmm8, mem(rcx, 0*32))
 	//add(rdi, rcx)
 	
@@ -2066,12 +2084,14 @@ void bli_sgemmsup_rv_haswell_asm_2x2
 	label(.SROWSTORED)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm4)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm4)
 	vmovsd(xmm4, mem(rcx, 0*32))
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm6)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm6)
 	vmovsd(xmm6, mem(rcx, 0*32))
 	//add(rdi, rcx)
 	
@@ -2404,7 +2424,8 @@ void bli_sgemmsup_rv_haswell_asm_1x2
 	label(.SROWSTORED)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm4)
+	vmovsd(mem(rcx), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm4)
 	vmovsd(xmm4, mem(rcx, 0*32))
 	//add(rdi, rcx)
 	

--- a/kernels/haswell/3/sup/s6x16/bli_gemmsup_rv_haswell_asm_sMx2.c
+++ b/kernels/haswell/3/sup/s6x16/bli_gemmsup_rv_haswell_asm_sMx2.c
@@ -93,8 +93,8 @@ void bli_sgemmsup_rv_haswell_asm_6x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       auxinfo_t*          data,
+       cntx_t*             cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );
@@ -564,8 +564,8 @@ void bli_sgemmsup_rv_haswell_asm_5x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       auxinfo_t*          data,
+       cntx_t*             cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );
@@ -1021,8 +1021,8 @@ void bli_sgemmsup_rv_haswell_asm_4x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       auxinfo_t*          data,
+       cntx_t*             cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );
@@ -1428,8 +1428,8 @@ void bli_sgemmsup_rv_haswell_asm_3x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       auxinfo_t*          data,
+       cntx_t*             cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );
@@ -1828,8 +1828,8 @@ void bli_sgemmsup_rv_haswell_asm_2x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       auxinfo_t*          data,
+       cntx_t*             cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );
@@ -2178,8 +2178,8 @@ void bli_sgemmsup_rv_haswell_asm_1x2
        float*     restrict b, inc_t rs_b0, inc_t cs_b0,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       auxinfo_t*          data,
+       cntx_t*             cntx
      )
 {
 	//void*    a_next = bli_auxinfo_next_a( data );


### PR DESCRIPTION
This is a manual merge of [this commit from flame/blis](https://github.com/shadeMe/blis/commit/85003e9b779ab408037ac45a87033acd343f51a3) and some cherry-picked changes from [this one](https://github.com/flame/blis/commit/9fea633748ed27ef3853bba7cd955690c61092b4).