### PR TITLE
Fix OOB read in `bli_sgemmsup_rv_haswell_asm_6x2m`

### DIFF
--- a/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_s6x16m.c
+++ b/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_s6x16m.c
@@ -4502,7 +4502,8 @@ void bli_sgemmsup_rv_haswell_asm_6x2m
 	add(rdi, rcx)
 	
 	
-	vfmadd231ps(mem(rcx, 0*32), xmm3, xmm14)
+	vmovsd(mem(rcx, 0*32), xmm0)
+	vfmadd231ps(xmm0, xmm3, xmm14)
 	vmovsd(xmm14, mem(rcx, 0*32))
 	//add(rdi, rcx)
 	


### PR DESCRIPTION
Same fix as in b363244.